### PR TITLE
ENH: support new QIIME 2 metadata file format in 2018.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 **Note on versioning:** the version numbers used here match the version numbers displayed to users in the Chrome Web Store. Sometimes there are gaps between release versions (e.g., version 2 jumps to version 5). This happens because each separate upload of Keemei to the web store increments the version number, and sometimes multiple uploads are necessary before a release is finalized (e.g., if the release is reviewed by an add-ons advisor and updates are required before it can go public). Therefore, the version numbering used here in the changelog and tagged GitHub releases will match the public release version displayed in the web store.
 
+## Development version
+
+### Features
+* Added support for validating the new [QIIME 2](https://qiime2.org) metadata file format available in the project's `2018.2` release.
+
 ## Version 17 (2018-02-09)
 
 Minor release rebranding Keemei as an official QIIME 2 project.

--- a/src/App.gs
+++ b/src/App.gs
@@ -19,20 +19,20 @@ function onOpen(e) {
       .addToUi();
 };
 
+function validateQiime2() {
+  validateQiime2_();
+};
+
 function validateQiime1() {
   validate_(getQiime1FormatSpec_);
 };
 
-function validateQiime2() {
-  validate_(getQiime2FormatSpec_);
+function validateQiitaSampleInformationFile() {
+  validate_(getQiitaSampleInformationFormatSpec_);
 };
 
 function validateSrgd() {
   validate_(getSrgdFormatSpec_);
-};
-
-function validateQiitaSampleInformationFile() {
-  validate_(getQiitaSampleInformationFormatSpec_);
 };
 
 function clear() {

--- a/src/Qiime2Format.gs
+++ b/src/Qiime2Format.gs
@@ -1,80 +1,408 @@
-function getQiime2FormatSpec_(sheetData) {
-  var axisLabelRegex = /[^\/\\*<>?|$]/ig;
+/**
+ * TODO:
+ * - The code is pretty messy/complicated and could use some refactoring to decompose
+ *   functions, reduce duplication, etc. Consider this an MVP for now.
+ *
+ * - This validator doesn't use the "format spec" API used by the other validators.
+ *   Consider refactoring the code to reuse some of the existing functionality. For
+ *   now, this format implements everything itself except for reporting and rendering
+ *   the results.
+ *
+ * - There are lots of functions in this file (and the project as a whole), and everything
+ *   is in the global namespace. The functions in this file include the word "Q2" in their
+ *   names for now to avoid clashes and to make it clear that the functions are specific to
+ *   the QIIME 2 validator. Consider redesigning to group a format's functions into a single
+ *   namespace (perhaps some OOP would help here).
+ *
+ * - The code needs more comments/documentation.
+ *
+ * - The code could use some linting and style-checks for consistency.
+ *
+ * - Consider adding warnings to cells with leading/trailing whitespace.
+ *
+ * - Consider adding warnings to IDs that don't meet the "recommendations for identifiers"
+ *   in the QIIME 2 Metadata format spec.
+ */
 
-  var formatSpec = {
-    format: "QIIME 2 metadata file",
-    ignoredRowIdxs: getQiime2IgnoredRowIdxs_(sheetData),
-    headerValidation: [
-      {
-        validator: findDuplicates_,
-        args: ["Duplicate column label"]
-      },
-      {
-        validator: findInvalidCharacters_,
-        args: [axisLabelRegex, "errors", "column label"]
-      },
-      {
-        validator: findEmpty_,
-        args: ["errors"]
-      },
-      {
-        validator: findLeadingTrailingWhitespace_,
-        args: []
-      }
-    ],
-    columnValidation: {
-      "default": [
-        {
-          validator: findLeadingTrailingWhitespace_,
-          args: []
-        }
-      ],
-      columns: {}
-    }
-  };
+/**
+ * TODO: Rhino engine doesn't support data structures like Set and Map.
+ * Consider using a GAS shim library such as this one (it'd be better to
+ * inline the code rather than importing as a GAS library because libraries
+ * can slow down add-on loading time).
+ *
+ * http://ramblings.mcpher.com/Home/excelquirks/gassnips/es6shim
+ *
+ * For now, we'll fake Set objects. If a shim is added, there are likely other
+ * parts of the codebase that could take advantage of it too (some places are
+ * commented, some are not).
+ */
+var Q2IDHEADERS_ = {
+  caseInsensitive: {
+    "id": null,
+    "sampleid": null,
+    "sample id": null,
+    "sample-id": null,
+    "featureid": null,
+    "feature id": null,
+    "feature-id": null
+  },
 
-  var idColumnLabel = sheetData[getHeaderRowIdx_(sheetData, formatSpec.ignoredRowIdxs)][0];
-
-  formatSpec.columnValidation.columns[idColumnLabel] = [
-    {
-      validator: findDuplicates_,
-      args: ["Duplicate identifier"]
-    },
-    {
-      validator: findInvalidCharacters_,
-      args: [axisLabelRegex, "errors", "identifier"]
-    },
-    {
-      validator: findEmpty_,
-      args: ["errors"]
-    },
-    {
-      validator: findLeadingTrailingWhitespace_,
-      args: []
-    }
-  ];
-
-  return formatSpec;
+  exactMatch: {
+    "#SampleID": null,
+    "#Sample ID": null,
+    "#OTUID": null,
+    "#OTU ID": null,
+    "sample_name": null
+  }
 };
 
-function getQiime2IgnoredRowIdxs_(sheetData) {
-  var ignored = new Array(sheetData.length);
+var Q2COLUMNTYPES_ = {
+  "categorical": null,
+  "numeric": null
+};
+
+// Ported from QIIME 2's Metadata reader regex, tested at https://regexr.com/
+// Credit: https://stackoverflow.com/a/4703508/3776794
+var NUMERICREGEX_ = /^[-+]?(?:(?:\d*\.\d+)|(?:\d+\.?))(?:[Ee][+-]?\d+)?$/;
+
+function validateQiime2_() {
+  var startTime = Date.now();
+
+  var sheet = SpreadsheetApp.getActiveSheet();
+  var sheetData = sheet.getDataRange().getDisplayValues();
+  trimLeadingTrailingWhitespace_(sheetData);
+  var cellCount = sheetData.length * sheetData[0].length;
+
+  var validationResults = getQiime2ValidationResults_(sheetData);
+
+  var report = {
+    format: "QIIME 2 metadata file",
+    validationResults: validationResults,
+    cellCount: cellCount,
+    runtime: Date.now() - startTime
+  };
+
+  renderSheetView_(sheet, report);
+  renderSidebarView_(sheet, report);
+  return report;
+};
+
+function trimLeadingTrailingWhitespace_(sheetData) {
+  for (var i = 0; i < sheetData.length; i++) {
+    var row = sheetData[i];
+    for (var j = 0; j < row.length; j++) {
+      row[j] = row[j].trim();
+    }
+  }
+};
+
+function trimTrailingEmptyCells_(row) {
+  var dataExtent = null;
+  for (var i = 0; i < row.length; i++) {
+    if (row[i] !== "") {
+      dataExtent = i;
+    }
+  }
+  return row.slice(0, dataExtent + 1);
+};
+
+function getQiime2ValidationResults_(sheetData) {
+  var validationResults = {};
+
+  var header = null;
+  var headerIdx = null;
   for (var i = 0; i < sheetData.length; i++) {
     var row = sheetData[i];
 
-    // Special case for QIIME 1 backwards compatibility.
-    if ((i == 0) && (row[0] === '#SampleID')) {
+    if (isQ2Comment_(row)) {
+      continue;
+    }
+    else if (isQ2Empty_(row)) {
+      continue;
+    }
+    else if (isQ2Directive_(row)) {
+      var position = [i, 0];
+      addCellError_(validationResults, position, ["Found directive before header. Directives may only appear immediately after the header."]);
+    }
+    else {
+      // Trim trailing empty cells from the header so that directives and data rows
+      // can be length-checked against the header (values should be within the bounds
+      // of the header).
+      header = trimTrailingEmptyCells_(row);
+      headerIdx = i;
+      break;
+    }
+  }
+
+  if (header === null) {
+    var position = [0, 0];
+    addCellError_(validationResults, position, ["Failed to locate header. The sheet may be empty, or consists only of comments or empty rows."]);
+    // TODO avoid early return
+    return validationResults;
+  }
+
+  validateQ2Header_(validationResults, header, headerIdx);
+
+  var typesDirective = null;
+  var typesDirectiveIdx = null;
+  var dataIdx = null;
+  // Iterate over rows directly after the header.
+  for (var i = headerIdx + 1; i < sheetData.length; i++) {
+    var row = sheetData[i];
+
+    if (!isQ2Directive_(row)) {
+      dataIdx = i;
+      break;
+    }
+
+    if (isQ2TypesDirective_(row)) {
+      if (typesDirective === null) {
+        typesDirective = trimTrailingEmptyCells_(row);
+        typesDirectiveIdx = i;
+      }
+      else {
+        var position = [i, 0];
+        addCellError_(validationResults, position, ["Found duplicate #q2:types directive. Each directive may only be specified a single time."]);
+      }
+    }
+    else {
+      var position = [i, 0];
+      addCellError_(validationResults, position, ["Unrecognized directive. Only the #q2:types directive is supported at this time."]);
+    }
+  }
+
+  if (typesDirective !== null) {
+    validateQ2TypesDirective_(validationResults, typesDirective, typesDirectiveIdx, header);
+  }
+
+  if (dataIdx === null) {
+    // TODO this check happens here and within `validateQ2Data_`. Refactor to have the check
+    // only happen in `validateQ2Data_` (which might avoid the early return below too).
+    var position = [headerIdx, 0];
+    addCellError_(validationResults, position, ["At least one ID must be present after the header and any optional directives."]);
+    // TODO avoid early return
+    return validationResults;
+  }
+
+  validateQ2Data_(validationResults, sheetData, dataIdx, header, headerIdx, typesDirective);
+
+  return validationResults;
+};
+
+function validateQ2Header_(validationResults, header, headerIdx) {
+  if (!isQ2Header_(header)) {
+    var position = [headerIdx, 0];
+    var message = ["Found unrecognized ID column name in the header. The first column name in the header must be one of these values:"];
+    // TODO this is duplicated below for column name clashes, refactor.
+    var caseInsensitive = Object.keys(Q2IDHEADERS_.caseInsensitive).sort();
+    var exactMatch = Object.keys(Q2IDHEADERS_.exactMatch).sort();
+    message.push(Utilities.formatString("Case-insensitive: %s", caseInsensitive.join(", ")));
+    message.push(Utilities.formatString("Case-sensitive: %s", exactMatch.join(", ")));
+    addCellError_(validationResults, position, message);
+  }
+
+  // TODO `seen` could be a Set object in the future.
+  var seen = {};
+  for (var i = 0; i < header.length; i++) {
+    var value = header[i];
+    var position = [headerIdx, i]
+
+    if (value === "") {
+      addCellError_(validationResults, position, ["Each column in the header must have a name."]);
+    }
+
+    // TODO this doesn't mark the first occurrence of a column that's duplicated.
+    // It'd be helpful to mark all occurrences and note which cells are duplicates
+    // in the error message.
+    if (seen.hasOwnProperty(value)) {
+      addCellError_(validationResults, position, ["Duplicate column name. This column name occurs earlier in the header."]);
+    }
+    else {
+      seen[value] = true;
+    }
+
+    // Skip validation of the first cell because we're expecting that value to be an
+    // ID column header.
+    if (i != 0 && isQ2Header_([value])) {
+      var message = ["Column name conflicts with a name reserved for the ID column. Reserved ID column names:"];
+      // TODO this is duplicated above at the start of this function, refactor.
+      var caseInsensitive = Object.keys(Q2IDHEADERS_.caseInsensitive).sort();
+      var exactMatch = Object.keys(Q2IDHEADERS_.exactMatch).sort();
+      message.push(Utilities.formatString("Case-insensitive: %s", caseInsensitive.join(", ")));
+      message.push(Utilities.formatString("Case-sensitive: %s", exactMatch.join(", ")));
+      addCellError_(validationResults, position, message);
+    }
+  }
+};
+
+function validateQ2TypesDirective_(validationResults, typesDirective, typesDirectiveIdx, header) {
+  // Skip the first cell because we know it is "#q2:types" at this point.
+  for (var i = 1; i < typesDirective.length; i++) {
+    var value = typesDirective[i];
+    var position = [typesDirectiveIdx, i]
+
+    if (value !== "" && !Q2COLUMNTYPES_.hasOwnProperty(value.toLowerCase())) {
+      var columnTypes = Object.keys(Q2COLUMNTYPES_).sort();
+      var message = [Utilities.formatString("Unrecognized column type specified in #q2:types directive. Supported column types (case-insensitive): %s", columnTypes.join(", "))];
+      addCellError_(validationResults, position, message);
+    }
+
+    // TODO a similar check happens below in `validateQ2Data_`. Refactor code to reduce duplication.
+    if (i >= header.length) {
+      addCellError_(validationResults, position, ["Cell is past the boundaries declared by the header. Please check that this cell's column has a name in the header."]);
+    }
+  }
+};
+
+function validateQ2Data_(validationResults, sheetData, dataIdx, header, headerIdx, typesDirective) {
+  // Convert all values in the types directive to lowercase in order to speed up lookups in
+  // the inner loop below (otherwise each directive cell would need to be converted to lowercase
+  // each time is it accessed).
+  if (typesDirective !== null) {
+    typesDirective = typesDirective.map(function(cell) {
+      return cell.toLowerCase();
+    });
+  }
+
+  // TODO `ids` could be a Set object in the future.
+  var ids = {};
+  for (var i = dataIdx; i < sheetData.length; i++) {
+    var row = sheetData[i];
+
+    if (isQ2Comment_(row)) {
+      continue;
+    }
+    else if (isQ2Empty_(row)) {
+      continue;
+    }
+    else if (isQ2Directive_(row)) {
+      var position = [i, 0];
+      addCellError_(validationResults, position, ["Found directive outside of the directives section. Directives may only appear immediately after the header."]);
+      // Don't try to validate a misplaced comment directive row.
       continue;
     }
 
-    // We can only validate comment lines because it isn't
-    // possible to export a Google Sheet as TSV with blank
-    // lines (i.e. only spaces in the line) -- tab delimiters
-    // are always included in the exported row, so the row
-    // won't be ignored when QIIME 2 loads the file.
-    if (startsWith_(row[0], "#")) {
-      ignored[i] = true;
+    // We now have a data row to validate. Trim cells off the end that should be ignored.
+    row = trimTrailingEmptyCells_(row);
+
+    if (isQ2Header_(row)) {
+      var position = [i, 0];
+      var message = ["Metadata ID conflicts with a name reserved for the ID column header. Reserved ID column names:"];
+      // TODO this is duplicated above at the start of this function, refactor.
+      var caseInsensitive = Object.keys(Q2IDHEADERS_.caseInsensitive).sort();
+      var exactMatch = Object.keys(Q2IDHEADERS_.exactMatch).sort();
+      message.push(Utilities.formatString("Case-insensitive: %s", caseInsensitive.join(", ")));
+      message.push(Utilities.formatString("Case-sensitive: %s", exactMatch.join(", ")));
+      addCellError_(validationResults, position, message);
+    }
+
+    var id = row[0];
+    if (id === "") {
+      var position = [i, 0];
+      addCellError_(validationResults, position, ["Each ID must have a name."]);
+    }
+
+    // TODO this doesn't mark the first occurrence of an ID that's duplicated.
+    // It'd be helpful to mark all occurrences and note which cells are duplicates
+    // in the error message.
+    if (ids.hasOwnProperty(id)) {
+      var position = [i, 0];
+      addCellError_(validationResults, position, ["Duplicate ID. The ID occurs earlier in this column."]);
+    }
+    else {
+      ids[id] = true;
+    }
+
+    // Now that the ID is validated, check that the other values in the row can be converted to numbers
+    // if they are declared to be numeric. Also check that values don't overflow past the header's length.
+    for (var j = 1; j < row.length; j++) {
+      var value = row[j];
+      var position = [i, j];
+
+      if (typesDirective !== null && typesDirective[j] === "numeric") {
+        if (value !== "" && !NUMERICREGEX_.test(value)) {
+          addCellError_(validationResults, position, ["Cannot interpret value as a number. #q2:types directive declares this column numeric."]);
+        }
+      }
+
+      // TODO a similar check happens above in `validateQ2TypesDirective_`. Refactor code to reduce duplication.
+      if (j >= header.length) {
+        addCellError_(validationResults, position, ["Cell is past the boundaries declared by the header. Please check that this cell's column has a name in the header."]);
+      }
     }
   }
-  return ignored;
+
+  if (Object.keys(ids).length < 1) {
+    // TODO this check happens here and earlier within `getQiime2ValidationResults_`.
+    // Refactor to have the check only happen here.
+    var position = [headerIdx, 0];
+    addCellError_(validationResults, position, ["At least one ID must be present after the header and any optional directives."]);
+  }
+};
+
+function isQ2Header_(row) {
+  return (
+    Q2IDHEADERS_.exactMatch.hasOwnProperty(row[0]) ||
+    Q2IDHEADERS_.caseInsensitive.hasOwnProperty(row[0].toLowerCase())
+  );
+};
+
+function isQ2Directive_(row) {
+  return startsWith_(row[0], "#q2:");
+};
+
+function isQ2TypesDirective_(row) {
+  return row[0] === "#q2:types";
+};
+
+function isQ2Comment_(row) {
+  return (
+    startsWith_(row[0], "#") &&
+    !isQ2Directive_(row) &&
+    !isQ2Header_(row)
+  );
+};
+
+function isQ2Empty_(row) {
+  return row.every(function(cell) {
+    return cell === "";
+  });
+};
+
+function addCellError_(validationResults, position, message) {
+  var a1 = getA1Notation_(position);
+
+  if (validationResults.hasOwnProperty(a1)) {
+    if (validationResults[a1].hasOwnProperty("errors")) {
+      validationResults[a1].errors.push(message);
+    }
+    else {
+      validationResults[a1].errors = [message];
+    }
+  }
+  else {
+    validationResults[a1] = {
+      position: position,
+      errors: [message],
+    };
+  }
+};
+
+function addCellWarning_(validationResults, position, message) {
+  var a1 = getA1Notation_(position);
+
+  if (validationResults.hasOwnProperty(a1)) {
+    if (validationResults[a1].hasOwnProperty("warnings")) {
+      validationResults[a1].warnings.push(message);
+    }
+    else {
+      validationResults[a1].warnings = [message];
+    }
+  }
+  else {
+    validationResults[a1] = {
+      position: position,
+      warnings: [message],
+    };
+  }
 };

--- a/src/QiitaSampleInformationFormat.gs
+++ b/src/QiitaSampleInformationFormat.gs
@@ -4,7 +4,7 @@ function getQiitaSampleInformationFormatSpec_(sheetData) {
   var requiredCentralizedFields = ["sample_type", "physical_specimen_remaining", "dna_extracted", "latitude", "longitude", "host_subject_id"];
 
   return {
-    format: "Qiita sample information",
+    format: "Qiita sample information file",
     ignoredRowIdxs: [],
     headerValidation: [
       {

--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -7,12 +7,12 @@
   <body>
     <div class="sidebar">
     <? if (data.summary.invalidCount < 1) { ?>
-      <h1>All's well! Sheet <b><?= data.sheetName ?></b> is in valid <b><?= data.format ?></b> format.</h1>
+      <h1>Good news! Sheet <b><?= data.sheetName ?></b> is a valid <b><?= data.format ?></b>.</h1>
     <? }
     else { ?>
       <div class="block">
       <h1>Validation report for sheet <b><?= data.sheetName ?></b></h1>
-      <span class="gray"><?= data.format ?> format</span>
+      <span class="gray"><?= data.format ?></span>
       <fieldset>
         <legend>Summary</legend>
         <b><?= data.summary.invalidCount ?></b> invalid cells<br/>

--- a/src/SrgdFormat.gs
+++ b/src/SrgdFormat.gs
@@ -1,6 +1,6 @@
 function getSrgdFormatSpec_(sheetData) {
   return {
-    format: "SRGD",
+    format: "SRGD file",
     ignoredRowIdxs: [],
     headerValidation: [
       {


### PR DESCRIPTION
Added support for validating the new QIIME 2 metadata file format available in the project's `2018.2` release.

The validator is an MVP; the code needs some refactoring and cleanup (see comments at the top of `Qiime2Format.gs` for details).

Fixes #91.