### PR TITLE
REL: Version 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 **Note on versioning:** the version numbers used here match the version numbers displayed to users in the Chrome Web Store. Sometimes there are gaps between release versions (e.g., version 2 jumps to version 5). This happens because each separate upload of Keemei to the web store increments the version number, and sometimes multiple uploads are necessary before a release is finalized (e.g., if the release is reviewed by an add-ons advisor and updates are required before it can go public). Therefore, the version numbering used here in the changelog and tagged GitHub releases will match the public release version displayed in the web store.
 
-## Development version
+## Version 18 (2018-02-14)
+
+This release adds support for validating the new [QIIME 2](https://qiime2.org) metadata file format available in the project's `2018.2` release.
 
 ### Features
 * Added support for validating the new [QIIME 2](https://qiime2.org) metadata file format available in the project's `2018.2` release.


### PR DESCRIPTION
This release adds support for validating the new QIIME 2 metadata file format available in the project's `2018.2` release.